### PR TITLE
加入 .gitattributes 並重新標準化版控的文字檔

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+.gitattributes text
+*.txt text
+*.htm text


### PR DESCRIPTION
上一個版本不小心改成混合換行字元了。應該是因為你的檔案都用CRLF換行，而我的取代腳本是針對LF寫的。

如果不處理的話，比對時會被程式當做幾乎每一行都有異動，像這樣： https://github.com/chiuinan/chiuinan.github.io/commit/2bdc7febb5cc1b79412943915d7ce316603110b7#diff-141036e914e644ea7864e9965c6945ffe36ac00803678dd21067d1f35ceda1a9

我幫你加上 .gitattributes，定義 txt 和 htm 一律視為文字檔，這樣無論本地的檔案使用的換行字元是 CRLF 或 LF 或混用， git 都會在把檔案加入版本庫時統一為 LF，至於 checkout 到本地會使用什麼，則視系統平台和版本庫本身的 config 而定。

同時也把已記錄的檔案按照 .gitattributes 的定義重新標準化，以這些檔案為例就是把 CRLF 統一為 LF。

應該可以直接 merge，如果要自己手動操作的話，要先加入 .gitattributes，再自己用 git CLI 下命令：

```sh
git add . --renormalize
git commit -m '標準化換行字元'
```