### PR TITLE
自動產生遊戲總表

### DIFF
--- a/game/game/cgame11.htm
+++ b/game/game/cgame11.htm
@@ -71,7 +71,7 @@
  <td>***
  <td>1997
  <td>精訊
- <td>2CD (152)
+ <td>2CD (<data>152</data>)
  <td>需光碟
  <td>OGCD022
 
@@ -107,7 +107,7 @@
  <td>*****
  <td>1999
  <td>大宇
- <td>4CD/1DVD (1095)
+ <td>4CD/1DVD (<data>1095</data>)
  <td>Windows
  <td>OGCD003
 
@@ -116,7 +116,7 @@
  <td>*****
  <td>2000
  <td>大宇
- <td>4CD/1DVD (1318)
+ <td>4CD/1DVD (<data>1318</data>)
  <td>Windows
  <td>OGCD004
 
@@ -125,7 +125,7 @@
  <td>****
  <td>2002
  <td>大宇
- <td>4CD (1357)
+ <td>4CD (<data>1357</data>)
  <td>Windows
  <td>OGCD005
 
@@ -134,7 +134,7 @@
  <td>****
  <td>2004
  <td>大宇
- <td>4CD (1465)<br>1DVD (1696)
+ <td>4CD (<data>1465</data>)<br>1DVD (1696)
  <td>Windows
  <td>OGCD006
 
@@ -143,7 +143,7 @@
  <td>****
  <td>2006
  <td>大宇
- <td>3CD (1126)
+ <td>3CD (<data>1126</data>)
  <td>Windows
  <td>OGCD007
 
@@ -197,7 +197,7 @@
  <td>*****
  <td>1995
  <td>大宇
- <td>1CD (28.3)
+ <td>1CD (<data>28.3</data>)
  <td>無
  <td>DISK050,SGCD011
 
@@ -206,7 +206,7 @@
  <td>*****
  <td>2001
  <td>大宇
- <td>4CD (1439)
+ <td>4CD (<data>1439</data>)
  <td>Windows
  <td>SGCD008
 
@@ -215,7 +215,7 @@
  <td>****
  <td>2002
  <td>大宇
- <td>4CD (1517)<br>1DVD (1831)
+ <td>4CD (<data>1517</data>)<br>1DVD (1831)
  <td>Windows
  <td>OGCD002
 
@@ -224,7 +224,7 @@
  <td>*****
  <td>2003
  <td>大宇
- <td>4CD/1DVD (1278)
+ <td>4CD/1DVD (<data>1278</data>)
  <td>Windows
  <td>OGCD033
 
@@ -233,7 +233,7 @@
  <td>*****
  <td>2004
  <td>大宇
- <td>4CD (1610)
+ <td>4CD (<data>1610</data>)
  <td>Windows
  <td>OGCD031
 
@@ -251,7 +251,7 @@
  <td>*****
  <td>2000
  <td>大宇
- <td nowrap>3CD/1DVD (1224)
+ <td nowrap>3CD/1DVD (<data>1224</data>)
  <td>Windows
  <td>OGCD012
 
@@ -441,7 +441,7 @@
  <td>****
  <td>2000
  <td>智冠
- <td>4CD (988)
+ <td>4CD (<data>988</data>)
  <td>Windows
  <td>OGCD023
 
@@ -477,7 +477,7 @@
  <td>***
  <td>1997
  <td>智冠
- <td>1CD (26.6)
+ <td>1CD (<data>26.6</data>)
  <td>無
  <td>OGCD037
 
@@ -486,7 +486,7 @@
  <td>***
  <td>1997
  <td>智冠
- <td>2CD (438)
+ <td>2CD (<data>438</data>)
  <td>需光碟
  <td>OGCD014
 
@@ -693,7 +693,7 @@
  <td>*****
  <td>1999
  <td>宇峻
- <td>4CD/1DVD (903)
+ <td>4CD/1DVD (<data>903</data>)
  <td>Windows
  <td>OGCD032
 
@@ -702,7 +702,7 @@
  <td>*****
  <td>2000
  <td>宇峻
- <td>4CD/1DVD (666)
+ <td>4CD/1DVD (<data>666</data>)
  <td>Windows
  <td>OGCD034(CD損壞)
 
@@ -711,7 +711,7 @@
  <td>****
  <td>2002
  <td>宇峻
- <td>4CD/1DVD (1421)
+ <td>4CD/1DVD (<data>1421</data>)
  <td>Windows
  <td>OGCD016
 
@@ -720,7 +720,7 @@
  <td>*****
  <td>2006
  <td>宇峻
- <td>4CD (2379)
+ <td>4CD (<data>2379</data>)
  <td>Windows
  <td>OGCD015
 
@@ -729,7 +729,7 @@
  <td>*****
  <td>2001
  <td>宇峻
- <td>4CD/1DVD (1002)
+ <td>4CD/1DVD (<data>1002</data>)
  <td>Windows
  <td>OGCD010(CD損壞)
 
@@ -738,7 +738,7 @@
  <td>****
  <td>2000
  <td>昱泉
- <td>4CD (1102)
+ <td>4CD (<data>1102</data>)
  <td>Windows，需光碟
  <td>OGCD026
 
@@ -747,7 +747,7 @@
  <td>***
  <td>2002
  <td>新瑞獅 (新造)
- <td>4CD (1327)
+ <td>4CD (<data>1327</data>)
  <td>Windows
  <td>OGCD009
 

--- a/game/game/cgame11.htm
+++ b/game/game/cgame11.htm
@@ -8,12 +8,9 @@
 
 <body>
 
-<div style="text-align: center; color: #800000; font-family: 標楷體;">
-<b><big><big>中文回合角色扮演類</big></big></b>
-</div>
-
 <small>
 <table border="1" width="100%" cellspacing="0" cellpadding="2">
+<caption style="text-align:center; color:#800000; font:bold 1.8em 標楷體;">中文回合角色扮演類</caption>
 
 <tr bgcolor=blue style="color:white; position:sticky; top:0;">
  <td>遊戲名稱

--- a/game/game/cgame12.htm
+++ b/game/game/cgame12.htm
@@ -44,7 +44,7 @@
  <td>***
  <td>1995
  <td>大宇
- <td>1CD (2.8)
+ <td>1CD (<data>2.8</data>)
  <td>無
  <td>DISK003,SGCD056
 
@@ -53,7 +53,7 @@
  <td>*****
  <td>1998
  <td>大宇
- <td>2CD (1058)
+ <td>2CD (<data>1058</data>)
  <td>需光碟
  <td>OGCD017
 
@@ -125,7 +125,7 @@
  <td>****
  <td>2000
  <td>奧汀 (智冠)
- <td>3CD (1135)
+ <td>3CD (<data>1135</data>)
  <td>Windows，需光碟
  <td>OGCD011
 
@@ -134,7 +134,7 @@
  <td>****
  <td>2000
  <td>數碼科技 (智冠)
- <td>2CD (448)
+ <td>2CD (<data>448</data>)
  <td>WinXP，需光碟
  <td>OGCD020
 
@@ -143,7 +143,7 @@
  <td>*****
  <td>2002
  <td>金山軟件 (智冠)
- <td>2CD (1176)
+ <td>2CD (<data>1176</data>)
  <td>Windows，需光碟
  <td>OGCD028
 
@@ -224,7 +224,7 @@
  <td>*****
  <td>1991
  <td>Falcom (天堂鳥)
- <td>1CD (4.2)
+ <td>1CD (<data>4.2</data>)
  <td>無
  <td>OGCD036
 
@@ -260,7 +260,7 @@
  <td>*****
  <td>1998
  <td>New World Computing
- <td>2CD (391)
+ <td>2CD (<data>391</data>)
  <td>Windows
  <td>OGCD018
 
@@ -269,7 +269,7 @@
  <td>*****
  <td>1999
  <td>New World Computing
- <td>2CD (539)
+ <td>2CD (<data>539</data>)
  <td>Windows
  <td>SGCD003
 
@@ -278,7 +278,7 @@
  <td>*****
  <td>2000
  <td>New World Computing
- <td>2CD (576)
+ <td>2CD (<data>576</data>)
  <td>Windows
  <td>OGCD035
 
@@ -296,7 +296,7 @@
  <td>****
  <td>2002
  <td>創意鷹翔 (元古)
- <td>2CD (910)
+ <td>2CD (<data>910</data>)
  <td>Windows，需光碟
  <td>OGCD029
 
@@ -305,7 +305,7 @@
  <td>*****
  <td>2004
  <td>英特衛
- <td>2CD (908)
+ <td>2CD (<data>908</data>)
  <td>Windows
  <td>OGCD001
 
@@ -314,7 +314,7 @@
  <td>*****
  <td>2004
  <td>Larian (英特衛)
- <td>2CD (999)
+ <td>2CD (<data>999</data>)
  <td>Windows
  <td>OGCD027
 

--- a/game/game/cgame12.htm
+++ b/game/game/cgame12.htm
@@ -8,12 +8,9 @@
 
 <body>
 
-<div style="text-align: center; color: #800000; font-family: 標楷體;">
-<b><big><big>中文即時角色扮演類</big></big></b>
-</div>
-
 <small>
 <table border="1" width="100%" cellspacing="0" cellpadding="2">
+<caption style="text-align:center; color:#800000; font:bold 1.8em 標楷體;">中文即時角色扮演類</caption>
 
 <tr bgcolor=blue style="color:white; position:sticky; top:0;">
  <td>遊戲名稱

--- a/game/game/cgame21.htm
+++ b/game/game/cgame21.htm
@@ -98,7 +98,7 @@
  <td>*****
  <td>1995
  <td>Legend<br>(智冠)
- <td>1CD (275)
+ <td>1CD (<data>275</data>)
  <td>無
  <td>OGCD024
 

--- a/game/game/cgame21.htm
+++ b/game/game/cgame21.htm
@@ -8,12 +8,9 @@
 
 <body>
 
-<div style="text-align: center; color: #800000; font-family: 標楷體;">
-<b><big><big>中文冒險解謎類</big></big></b>
-</div>
-
 <small>
 <table border="1" width="100%" cellspacing="0" cellpadding="2">
+<caption style="text-align:center; color:#800000; font:bold 1.8em 標楷體;">中文冒險解謎類</caption>
 
 <tr bgcolor=blue style="color:white; position:sticky; top:0;">
  <td>遊戲名稱

--- a/game/game/cgame21.htm
+++ b/game/game/cgame21.htm
@@ -98,7 +98,7 @@
  <td>*****
  <td>1995
  <td>Legend<br>(智冠)
- <td>1CD<br>275
+ <td>1CD (275)
  <td>無
  <td>OGCD024
 

--- a/game/game/cgame22.htm
+++ b/game/game/cgame22.htm
@@ -8,12 +8,9 @@
 
 <body>
 
-<div style="text-align: center; color: #800000; font-family: 標楷體;">
-<b><big><big>中文故事劇情類</big></big></b>
-</div>
-
 <small>
 <table border="1" width="100%" cellspacing="0" cellpadding="2">
+<caption style="text-align:center; color:#800000; font:bold 1.8em 標楷體;">中文故事劇情類</caption>
 
 <tr bgcolor=blue style="color:white; position:sticky; top:0;">
  <td>遊戲名稱

--- a/game/game/cgame22.htm
+++ b/game/game/cgame22.htm
@@ -98,7 +98,7 @@
  <td>****
  <td>1995
  <td>Abogado (華義)
- <td>1CD (3.4/34.4)
+ <td>1CD (<data>3.4</data>/<data>34.4</data>)
  <td><font color=red>18禁</font>
  <td>SGCD099
 
@@ -107,7 +107,7 @@
  <td>****
  <td>1997
  <td>Abogado (天堂鳥)
- <td>1CD (4.9/31.0)
+ <td>1CD (<data>4.9</data>/<data>31.0</data>)
  <td><font color=red>18禁</font>
  <td>SGCD031
 

--- a/game/game/cgame31.htm
+++ b/game/game/cgame31.htm
@@ -8,12 +8,9 @@
 
 <body>
 
-<div style="text-align: center; color: #800000; font-family: 標楷體;">
-<b><big><big>中文策略角色扮演類</big></big></b>
-</div>
-
 <small>
 <table border="1" width="100%" cellspacing="0" cellpadding="2">
+<caption style="text-align:center; color:#800000; font:bold 1.8em 標楷體;">中文策略角色扮演類</caption>
 
 <tr bgcolor=blue style="color:white; position:sticky; top:0;">
  <td>遊戲名稱

--- a/game/game/cgame31.htm
+++ b/game/game/cgame31.htm
@@ -107,7 +107,7 @@
  <td>****
  <td>1994
  <td>漢堂
- <td>1CD (5.3)
+ <td>1CD (<data>5.3</data>)
  <td>無
  <td>SGCD001
 
@@ -116,7 +116,7 @@
  <td>*****
  <td>1995
  <td>漢堂
- <td>1CD (4.9)
+ <td>1CD (<data>4.9</data>)
  <td>無
  <td>SGCD001
 
@@ -125,7 +125,7 @@
  <td>*****
  <td>1997
  <td>漢堂
- <td>2CD (25.2/106)
+ <td>2CD (<data>25.2</data>/<data>106</data>)
  <td>無
  <td>OGCD021
 
@@ -143,7 +143,7 @@
  <td>*****
  <td>2001
  <td>光譜
- <td>2CD (478)
+ <td>2CD (<data>478</data>)
  <td>Windows
  <td>SGCD046
 

--- a/game/game/cgame32.htm
+++ b/game/game/cgame32.htm
@@ -8,12 +8,9 @@
 
 <body>
 
-<div style="text-align: center; color: #800000; font-family: 標楷體;">
-<b><big><big>中文計策戰略類</big></big></b>
-</div>
-
 <small>
 <table border="1" width="100%" cellspacing="0" cellpadding="2">
+<caption style="text-align:center; color:#800000; font:bold 1.8em 標楷體;">中文計策戰略類</caption>
 
 <tr bgcolor=blue style="color:white; position:sticky; top:0;">
  <td>遊戲名稱

--- a/game/game/cgame32.htm
+++ b/game/game/cgame32.htm
@@ -80,7 +80,7 @@
  <td>*****
  <td>1997
  <td>KOEI
- <td>1CD (79.6)
+ <td>1CD (<data>79.6</data>)
  <td>Windows
  <td>OGCD013(CD損壞)
 

--- a/game/game/cgame33.htm
+++ b/game/game/cgame33.htm
@@ -35,7 +35,7 @@
  <td>*****
  <td>1997
  <td>智冠
- <td>1CD (27.3)
+ <td>1CD (<data>27.3</data>)
  <td>無
  <td>OGCD25
 
@@ -44,7 +44,7 @@
  <td>*****
  <td>2001
  <td>智冠
- <td>2CD (343)
+ <td>2CD (<data>343</data>)
  <td>Windows
  <td>OGCD8
 
@@ -179,7 +179,7 @@
  <td>*****
  <td>2003
  <td>伊思儷
- <td>1CD (207)
+ <td>1CD (<data>207</data>)
  <td>Windows，<font color=red>18禁</font>
  <td>SGCD24
 
@@ -188,7 +188,7 @@
  <td>****
  <td>2003
  <td>伊思儷
- <td>1CD (851)
+ <td>1CD (<data>851</data>)
  <td>Windows，<font color=red>18禁</font>，需光碟
  <td>SGCD23
 

--- a/game/game/cgame33.htm
+++ b/game/game/cgame33.htm
@@ -8,12 +8,9 @@
 
 <body>
 
-<div style="text-align: center; color: #800000; font-family: 標楷體;">
-<b><big><big>中文模擬養成類</big></big></b>
-</div>
-
 <small>
 <table border="1" width="100%" height="35" cellspacing="0" cellpadding="2">
+<caption style="text-align:center; color:#800000; font:bold 1.8em 標楷體;">中文模擬養成類</caption>
 
 <tr bgcolor=blue style="color:white; position:sticky; top:0;">
  <td>遊戲名稱

--- a/game/game/cgame41.htm
+++ b/game/game/cgame41.htm
@@ -995,7 +995,8 @@
 </table>
 </small>
 
-<p>
+<p></p>
+
 <small>
 <table border="1" width="100%" cellspacing="0" cellpadding="2">
 <caption style="text-align:center; color:#800000; font:bold 1.8em 標楷體;">中文牌類</caption>

--- a/game/game/cgame41.htm
+++ b/game/game/cgame41.htm
@@ -88,7 +88,7 @@
  <td>1997
  <td>上海鵬達 (創越)
  <td>圍棋
- <td>1CD
+ <td>1CD<data>
  <td>Win31/XP
  <td>SGCD092
 
@@ -118,7 +118,7 @@
  <td>1997
  <td>普威爾
  <td>圍棋
- <td>1CD
+ <td>1CD<data>
  <td>Win31/XP
  <td>OGCD030
 
@@ -178,7 +178,7 @@
  <td>2002
  <td>新造科技
  <td>圍棋
- <td>2CD
+ <td>2CD<data>
  <td>Windows
  <td>SGCD082
 
@@ -188,7 +188,7 @@
  <td>2002
  <td>弈緣
  <td>圍棋
- <td>1CD
+ <td>1CD<data>
  <td>Windows
  <td>SGCD119
 
@@ -268,7 +268,7 @@
  <td>1997
  <td>普威爾
  <td>象棋
- <td>1CD
+ <td>1CD<data>
  <td>Win31/XP
  <td>OGCD030
 
@@ -288,7 +288,7 @@
  <td>1997
  <td>晟業
  <td>象棋
- <td>1CD
+ <td>1CD<data>
  <td>Win31/XP
  <td>SGCD016
 
@@ -308,7 +308,7 @@
  <td>1998
  <td>晟業
  <td>象棋
- <td>1CD
+ <td>1CD<data>
  <td>Win31/95/XP
  <td>SGCD094
 
@@ -318,7 +318,7 @@
  <td>1998
  <td>晟業
  <td>象棋
- <td>1CD
+ <td>1CD<data>
  <td>Windows
  <td>SGCD005
 
@@ -388,7 +388,7 @@
  <td>2002
  <td>新造科技
  <td>象棋
- <td>2CD
+ <td>2CD<data>
  <td>Windows
  <td>SGCD082
 
@@ -398,7 +398,7 @@
  <td>2002
  <td>新造科技
  <td>象棋
- <td>2CD
+ <td>2CD<data>
  <td>Windows
  <td>SGCD082
 
@@ -468,7 +468,7 @@
  <td>1997
  <td>普威爾
  <td>西洋棋
- <td>1CD
+ <td>1CD<data>
  <td>Win31/XP
  <td>OGCD030
 
@@ -478,7 +478,7 @@
  <td>2002
  <td>新造科技
  <td>西洋棋
- <td>2CD
+ <td>2CD<data>
  <td>Windows
  <td>SGCD082
 
@@ -518,7 +518,7 @@
  <td>1997
  <td>普威爾
  <td>五子棋
- <td>1CD
+ <td>1CD<data>
  <td>Win31/XP
  <td>OGCD030
 
@@ -588,7 +588,7 @@
  <td>2002
  <td>新造科技
  <td>五子棋
- <td>2CD
+ <td>2CD<data>
  <td>Windows
  <td>SGCD082
 
@@ -678,7 +678,7 @@
  <td>1997
  <td>普威爾
  <td>四子棋
- <td>1CD
+ <td>1CD<data>
  <td>Win31/XP
  <td>OGCD030
 
@@ -698,7 +698,7 @@
  <td>1997
  <td>普威爾
  <td>黑白棋
- <td>1CD
+ <td>1CD<data>
  <td>Win31/XP
  <td>OGCD030
 
@@ -708,7 +708,7 @@
  <td>2002
  <td>新造科技
  <td>黑白棋
- <td>2CD
+ <td>2CD<data>
  <td>Windows
  <td>SGCD082
 
@@ -798,7 +798,7 @@
  <td>1998
  <td>普威爾
  <td>暗棋
- <td>1CD
+ <td>1CD<data>
  <td>Windows
  <td>SGCD120
 
@@ -828,7 +828,7 @@
  <td>2002
  <td>新造科技
  <td>暗棋
- <td>2CD
+ <td>2CD<data>
  <td>Windows
  <td>SGCD082
 
@@ -858,7 +858,7 @@
  <td>1997
  <td>普威爾
  <td>西洋跳棋
- <td>1CD
+ <td>1CD<data>
  <td>Win31/XP
  <td>OGCD030
 
@@ -878,7 +878,7 @@
  <td>2000
  <td>智冠
  <td>跳棋
- <td>1CD
+ <td>1CD<data>
  <td>Windows
  <td>SGCD121
 
@@ -908,7 +908,7 @@
  <td>2002
  <td>新造科技
  <td>跳棋
- <td>2CD
+ <td>2CD<data>
  <td>Windows
  <td>SGCD082
 
@@ -938,7 +938,7 @@
  <td>2001
  <td>新造科技
  <td>陸軍棋
- <td>1CD
+ <td>1CD<data>
  <td>Windows
  <td>SGCD110
 
@@ -948,7 +948,7 @@
  <td>2002
  <td>新造科技
  <td>陸軍棋
- <td>2CD
+ <td>2CD<data>
  <td>Windows
  <td>SGCD082
 
@@ -968,7 +968,7 @@
  <td>2002
  <td>新造科技
  <td>孔明棋
- <td>2CD
+ <td>2CD<data>
  <td>Windows
  <td>SGCD082
 
@@ -978,7 +978,7 @@
  <td>1997
  <td>普威爾
  <td>雙陸棋
- <td>1CD
+ <td>1CD<data>
  <td>Win31/XP
  <td>OGCD030
 
@@ -988,7 +988,7 @@
  <td>1998
  <td>普威爾
  <td>西瓜棋
- <td>1CD
+ <td>1CD<data>
  <td>Windows
  <td>SGCD120
 
@@ -1037,7 +1037,7 @@
  <td>1997
  <td>普威爾
  <td>橋牌
- <td>1CD
+ <td>1CD<data>
  <td>Win31/XP
  <td>OGCD030
 

--- a/game/game/cgame41.htm
+++ b/game/game/cgame41.htm
@@ -8,12 +8,9 @@
 
 <body>
 
-<div style="text-align: center; color: #800000; font-family: 標楷體;">
-<b><big><big>中文棋類</big></big></b>
-</div>
-
 <small>
 <table border="1" width="100%" cellspacing="0" cellpadding="2">
+<caption style="text-align:center; color:#800000; font:bold 1.8em 標楷體;">中文棋類</caption>
 
 <tr bgcolor=blue style="color:white; position:sticky; top:0;">
  <td>遊戲名稱
@@ -999,12 +996,9 @@
 </small>
 
 <p>
-<div style="text-align: center; color: #800000; font-family: 標楷體;">
-<b><big><big>中文牌類</big></big></b>
-</div>
-
 <small>
 <table border="1" width="100%" cellspacing="0" cellpadding="2">
+<caption style="text-align:center; color:#800000; font:bold 1.8em 標楷體;">中文牌類</caption>
 
 <tr bgcolor=blue style="color:white; position:sticky; top:0;">
  <td>遊戲名稱

--- a/game/game/cgame41.htm
+++ b/game/game/cgame41.htm
@@ -78,7 +78,7 @@
  <td>1996
  <td>豐海
  <td>圍棋
- <td>1CD (0.1)
+ <td>1CD (<data>0.1</data>)
  <td>無
  <td>SGCD090
 
@@ -128,7 +128,7 @@
  <td>2001
  <td>普威爾
  <td>圍棋
- <td>1CD (3.1)
+ <td>1CD (<data>3.1</data>)
  <td>Windows
  <td>SGCD079
 
@@ -148,7 +148,7 @@
  <td>2000
  <td>晟業
  <td>圍棋
- <td>1CD (9.1)
+ <td>1CD (<data>9.1</data>)
  <td>Windows
  <td>SGCD113
 
@@ -158,7 +158,7 @@
  <td>2001
  <td>晟業
  <td>圍棋
- <td>1CD (56.5)
+ <td>1CD (<data>56.5</data>)
  <td>Windows
  <td>SGCD083
 
@@ -168,7 +168,7 @@
  <td>2002
  <td>晟業
  <td>圍棋
- <td>1CD (68.0)
+ <td>1CD (<data>68.0</data>)
  <td>Windows
  <td>SGCD097
 
@@ -258,7 +258,7 @@
  <td>1997
  <td>捷友
  <td>象棋
- <td>1CD (46.0)
+ <td>1CD (<data>46.0</data>)
  <td>Win9x
  <td>SGCD093
 
@@ -278,7 +278,7 @@
  <td>2000
  <td>普威爾
  <td>象棋
- <td>1CD (3.7)
+ <td>1CD (<data>3.7</data>)
  <td>Windows
  <td>SGCD115
 
@@ -348,7 +348,7 @@
  <td>1998
  <td>智冠
  <td>象棋
- <td>2CD (105)
+ <td>2CD (<data>105</data>)
  <td>無
  <td>SGCD036
 
@@ -358,7 +358,7 @@
  <td>1998
  <td>上海鵬達 (創越)
  <td>象棋
- <td>1CD (0.6)
+ <td>1CD (<data>0.6</data>)
  <td>Win31/XP
  <td>SGCD117
 
@@ -368,7 +368,7 @@
  <td>1999
  <td>不明
  <td>象棋
- <td>1CD (0.1)
+ <td>1CD (<data>0.1</data>)
  <td>Windows
  <td>SGCD122
 
@@ -378,7 +378,7 @@
  <td>1999
  <td>新造科技
  <td>象棋
- <td>1CD (1.2)
+ <td>1CD (<data>1.2</data>)
  <td>Windows
  <td>SGCD118
 
@@ -408,7 +408,7 @@
  <td>2002
  <td>伊世紀
  <td>象棋
- <td>1CD (7.1)
+ <td>1CD (<data>7.1</data>)
  <td>Windows
  <td>SGCD114
 
@@ -418,7 +418,7 @@
  <td>2002
  <td>伊世紀
  <td>象棋
- <td>1CD (1.1)
+ <td>1CD (<data>1.1</data>)
  <td>Windows
  <td>SGCD114
 
@@ -538,7 +538,7 @@
  <td>1998
  <td>智冠
  <td>五子棋
- <td>1CD (49.6)
+ <td>1CD (<data>49.6</data>)
  <td>無
  <td>SGCD019
 
@@ -568,7 +568,7 @@
  <td>2002
  <td>伊世紀
  <td>五子棋
- <td>1CD (1.9)
+ <td>1CD (<data>1.9</data>)
  <td>Windows
  <td>SGCD114
 
@@ -578,7 +578,7 @@
  <td>2002
  <td>伊世紀
  <td>五子棋
- <td>1CD (15.1)
+ <td>1CD (<data>15.1</data>)
  <td>Windows
  <td>SGCD114
 
@@ -758,7 +758,7 @@
  <td>1998
  <td>光譜
  <td>暗棋
- <td>1CD (27.0)
+ <td>1CD (<data>27.0</data>)
  <td>Windows
  <td>SCD73
 
@@ -778,7 +778,7 @@
  <td>1997
  <td>智冠
  <td>暗棋
- <td>1CD (48.0)
+ <td>1CD (<data>48.0</data>)
  <td>無
  <td>SGCD050
 
@@ -788,7 +788,7 @@
  <td>1999
  <td>智冠
  <td>暗棋
- <td>1CD (2.8)
+ <td>1CD (<data>2.8</data>)
  <td>WinXP
  <td>SGCD074
 
@@ -808,7 +808,7 @@
  <td>2000
  <td>伊世紀
  <td>暗棋
- <td>1CD (138)
+ <td>1CD (<data>138</data>)
  <td>Windows
  <td>SGCD116
 
@@ -818,7 +818,7 @@
  <td>2000
  <td>伊世紀
  <td>暗棋
- <td>1CD (145)
+ <td>1CD (<data>145</data>)
  <td>Windows
  <td>SGCD095
 
@@ -838,7 +838,7 @@
  <td>2005
  <td>極真科技
  <td>暗棋
- <td>1CD (337)
+ <td>1CD (<data>337</data>)
  <td>Windows
  <td>SGCD017
 
@@ -848,7 +848,7 @@
  <td>1997
  <td>力藝
  <td>三國棋
- <td>1CD (6.6)
+ <td>1CD (<data>6.6</data>)
  <td>Windows
  <td>SGCD035
 
@@ -888,7 +888,7 @@
  <td>2002
  <td>伊世紀
  <td>跳棋
- <td>1CD (66.2)
+ <td>1CD (<data>66.2</data>)
  <td>Windows
  <td>SGCD114
 
@@ -958,7 +958,7 @@
  <td>1998
  <td>普威爾
  <td>孔明棋
- <td>1CD (2.6)
+ <td>1CD (<data>2.6</data>)
  <td>Windows
  <td>SGCD101
 
@@ -1057,7 +1057,7 @@
  <td>1994
  <td>宏申
  <td>大老二
- <td>1CD (8.0)
+ <td>1CD (<data>8.0</data>)
  <td>無
  <td>SGCD044
 
@@ -1067,7 +1067,7 @@
  <td>2003
  <td>伊思儷
  <td>大老二
- <td>1CD (252)
+ <td>1CD (<data>252</data>)
  <td>Windows，<font color=red>18禁</font>
  <td>SGCD081
 
@@ -1097,7 +1097,7 @@
  <td>2002
  <td>伊世紀
  <td>單人接龍
- <td>1CD (4.1)
+ <td>1CD (<data>4.1</data>)
  <td>無
  <td>SGCD133
 
@@ -1107,7 +1107,7 @@
  <td>2002
  <td>伊世紀
  <td>單人接龍
- <td>1CD (4.3)
+ <td>1CD (<data>4.3</data>)
  <td>無
  <td>SGCD133
 
@@ -1117,7 +1117,7 @@
  <td>2002
  <td>伊世紀
  <td>單人接龍
- <td>1CD (4.4)
+ <td>1CD (<data>4.4</data>)
  <td>無
  <td>SGCD133
 
@@ -1127,7 +1127,7 @@
  <td>2002
  <td>伊世紀
  <td>單人接龍
- <td>1CD (3.9)
+ <td>1CD (<data>3.9</data>)
  <td>無
  <td>SGCD133
 
@@ -1137,7 +1137,7 @@
  <td>2002
  <td>伊世紀
  <td>單人接龍
- <td>1CD (3.7)
+ <td>1CD (<data>3.7</data>)
  <td>無
  <td>SGCD133
 
@@ -1147,7 +1147,7 @@
  <td>2002
  <td>伊世紀
  <td>單人接龍
- <td>1CD (4.0)
+ <td>1CD (<data>4.0</data>)
  <td>無
  <td>SGCD133
 
@@ -1157,7 +1157,7 @@
  <td>2002
  <td>伊世紀
  <td>單人接龍
- <td>1CD (4.3)
+ <td>1CD (<data>4.3</data>)
  <td>無
  <td>SGCD133
 
@@ -1167,7 +1167,7 @@
  <td>2002
  <td>伊世紀
  <td>單人接龍
- <td>1CD (3.7)
+ <td>1CD (<data>3.7</data>)
  <td>無
  <td>SGCD133
 
@@ -1217,7 +1217,7 @@
  <td>2001
  <td>捷思特
  <td>梭哈
- <td>1CD (7.5)
+ <td>1CD (<data>7.5</data>)
  <td>Windows
  <td>SGCD129
 
@@ -1227,7 +1227,7 @@
  <td>2002
  <td>伊世紀
  <td>梭哈
- <td>1CD (3.7)
+ <td>1CD (<data>3.7</data>)
  <td>WinXP，<font color=red>18禁</font>
  <td>SGCD133
 

--- a/game/game/cgame42.htm
+++ b/game/game/cgame42.htm
@@ -78,7 +78,7 @@
  <td>1997
  <td>大宇
  <td>16張四人
- <td>1CD (8.8)
+ <td>1CD (<data>8.8</data>)
  <td>無
  <td>DISK055,SGCD045
 
@@ -88,7 +88,7 @@
  <td>2003
  <td>大宇
  <td>16張四人
- <td>2CD (452)
+ <td>2CD (<data>452</data>)
  <td>Windows
  <td>SGCD012
 
@@ -117,7 +117,7 @@
  <td>1996
  <td>漢堂
  <td>16張四人
- <td>1CD (26.1)
+ <td>1CD (<data>26.1</data>)
  <td>無
  <td>SGCD075
 
@@ -147,7 +147,7 @@
  <td>2003
  <td>光譜
  <td>16張四人
- <td>1CD (133)
+ <td>1CD (<data>133</data>)
  <td>Windows
  <td>SGCD128
 
@@ -167,7 +167,7 @@
  <td>1997
  <td>帕米爾
  <td>16張四人
- <td>1CD (15.3)
+ <td>1CD (<data>15.3</data>)
  <td>Windows
  <td>SGCD124
 
@@ -187,7 +187,7 @@
  <td>2000
  <td>帕米爾 (第三波)
  <td>16張四人
- <td>2CD (45.5)
+ <td>2CD (<data>45.5</data>)
  <td>Windows
  <td>SGCD014
 
@@ -197,7 +197,7 @@
  <td>2001
  <td>帕米爾 (第三波)
  <td>16張四人
- <td>2CD (201)
+ <td>2CD (<data>201</data>)
  <td>Windows
  <td>SGCD055
 
@@ -207,7 +207,7 @@
  <td>2002
  <td>帕米爾
  <td>16張四人/雙人<br>13張四人/雙人
- <td>1CD (115)
+ <td>1CD (<data>115</data>)
  <td>Windows
  <td>SGCD007
 
@@ -217,7 +217,7 @@
  <td>1998
  <td>捷友
  <td>16張四人
- <td>1CD (52.8)
+ <td>1CD (<data>52.8</data>)
  <td>Windows
  <td>SGCD004
 
@@ -227,7 +227,7 @@
  <td>1999
  <td>捷友
  <td>16張四人
- <td>1CD (30.7)
+ <td>1CD (<data>30.7</data>)
  <td>Win9x
  <td>SGCD104
 
@@ -237,7 +237,7 @@
  <td>1998
  <td>向量科技
  <td>16張四人
- <td>1CD (363)
+ <td>1CD (<data>363</data>)
  <td>Windows
  <td>SGCD132
 
@@ -247,7 +247,7 @@
  <td>1999
  <td>向量科技
  <td>16張四人
- <td>1CD (372)
+ <td>1CD (<data>372</data>)
  <td>Windows
  <td>SGCD131
 
@@ -257,7 +257,7 @@
  <td>2000
  <td>向量科技
  <td>16張四人
- <td>1CD (358)
+ <td>1CD (<data>358</data>)
  <td>Windows
  <td>SGCD105
 
@@ -267,7 +267,7 @@
  <td>2001
  <td>向量科技
  <td>16張四人
- <td>1CD (25.5)
+ <td>1CD (<data>25.5</data>)
  <td>Windows
  <td>SGCD112
 
@@ -277,7 +277,7 @@
  <td>1999
  <td>龍愛
  <td>16張四人/雙人<br>13張四人/雙人
- <td>1CD (56.8)
+ <td>1CD (<data>56.8</data>)
  <td>Windows
  <td>SGCD030
 
@@ -287,7 +287,7 @@
  <td>2003
  <td>龍愛
  <td>16張四人/雙人<br>13張四人/雙人
- <td>1CD (73.1)
+ <td>1CD (<data>73.1</data>)
  <td>Windows
  <td>SGCD043
 
@@ -297,7 +297,7 @@
  <td>2001
  <td>捷思特
  <td>16張四人
- <td>1CD (21.8)
+ <td>1CD (<data>21.8</data>)
  <td>Windows
  <td>SGCD129
 
@@ -307,7 +307,7 @@
  <td>2001
  <td>冠捷
  <td>16張四人
- <td>1CD (56.4)
+ <td>1CD (<data>56.4</data>)
  <td>Windows
  <td>SGCD088
 
@@ -327,7 +327,7 @@
  <td>2003
  <td>冠捷
  <td>16張四人
- <td>1CD (45.2)
+ <td>1CD (<data>45.2</data>)
  <td>Windows，<font color=red>18禁</font>
  <td>SGCD085
 
@@ -337,7 +337,7 @@
  <td>2003
  <td>冠捷
  <td>16張四人
- <td>1CD (146)
+ <td>1CD (<data>146</data>)
  <td>Windows，<font color=red>18禁</font>
  <td>SGCD086
 
@@ -347,7 +347,7 @@
  <td>2003
  <td>冠捷
  <td>16張四人
- <td>1CD (46.6)
+ <td>1CD (<data>46.6</data>)
  <td>Windows，<font color=red>18禁</font>
  <td>SGCD084
 
@@ -377,7 +377,7 @@
  <td>2001
  <td>極真科技
  <td>16張四人
- <td>1CD (199)
+ <td>1CD (<data>199</data>)
  <td>Windows
  <td>SGCD051
 
@@ -387,7 +387,7 @@
  <td>2004
  <td>極真科技
  <td>16張四人
- <td>1CD (168)
+ <td>1CD (<data>168</data>)
  <td>Windows
  <td>SGCD034
 
@@ -397,7 +397,7 @@
  <td>2006
  <td>極真科技
  <td>16張四人
- <td>1CD (52.3)
+ <td>1CD (<data>52.3</data>)
  <td>Windows
  <td>SGCD033
 
@@ -407,7 +407,7 @@
  <td>2001
  <td>鈊象電子 (智冠/華彩)
  <td>16張四人<br>13張四人
- <td>1CD (49.8)
+ <td>1CD (<data>49.8</data>)
  <td>Windows
  <td>SGCD069
 
@@ -437,7 +437,7 @@
  <td>2003
  <td>尼奧科技 (智冠)
  <td>16張四人
- <td>1CD (231)
+ <td>1CD (<data>231</data>)
  <td>Windows
  <td>SGCD013
 
@@ -447,7 +447,7 @@
  <td>2002
  <td>伊思儷
  <td>16張四人
- <td>1CD (448)
+ <td>1CD (<data>448</data>)
  <td>WinXP，<font color=red>18禁</font>
  <td>SGCD125
 
@@ -457,7 +457,7 @@
  <td>2002
  <td>伊思儷
  <td>16張四人
- <td>1CD (251)
+ <td>1CD (<data>251</data>)
  <td>WinXP，<font color=red>18禁</font>
  <td>SGCD098
 
@@ -587,7 +587,7 @@
  <td>2004
  <td>龍元書報社
  <td>16張四人
- <td>1CD (46.6)
+ <td>1CD (<data>46.6</data>)
  <td>Windows
  <td>SGCD076
 
@@ -597,7 +597,7 @@
  <td>2005
  <td>朔太科技
  <td>16張四人/雙人
- <td>1CD (337)
+ <td>1CD (<data>337</data>)
  <td>WinXP，<font color=red>18禁</font>
  <td>SGCD022
 
@@ -607,7 +607,7 @@
  <td>2006
  <td>布雷格 (智冠)
  <td>16張四人/雙人
- <td>1CD (363)
+ <td>1CD (<data>363</data>)
  <td>Windows
  <td>SGCD077
 
@@ -617,7 +617,7 @@
  <td>2006
  <td>新造科技
  <td>16張四人
- <td>1CD (22.9)
+ <td>1CD (<data>22.9</data>)
  <td>Windows
  <td>SGCD078
 
@@ -627,7 +627,7 @@
  <td>2009
  <td>新造科技
  <td>16張四人<br>13張四人
- <td>1CD (80.7)
+ <td>1CD (<data>80.7</data>)
  <td>Windows
  <td>SGCD102
 
@@ -637,7 +637,7 @@
  <td>2007
  <td>靚盒子
  <td>16張四人
- <td>1CD (252)
+ <td>1CD (<data>252</data>)
  <td>WinXP
  <td>SGCD126
 
@@ -657,7 +657,7 @@
  <td>2000
  <td>新造科技
  <td>16張雙人
- <td>1CD (12.9)
+ <td>1CD (<data>12.9</data>)
  <td>Windows
  <td>SGCD103
 
@@ -677,7 +677,7 @@
  <td>2002
  <td>京群
  <td>16張雙人
- <td>1CD (163)
+ <td>1CD (<data>163</data>)
  <td>Windows，<font color=red>18禁</font>
  <td>SGCD100
 
@@ -717,7 +717,7 @@
  <td>2004
  <td>伊思儷
  <td>16張雙人
- <td>4CD (1454)
+ <td>4CD (<data>1454</data>)
  <td>Windows，<font color=red>18禁</font>
  <td>SGCD018
 
@@ -767,7 +767,7 @@
  <td>2000
  <td>光譜
  <td>13張四人
- <td>1CD (150)
+ <td>1CD (<data>150</data>)
  <td>Windows
  <td>SGCD015
 
@@ -867,7 +867,7 @@
  <td>1993
  <td>Active (天堂鳥)
  <td>13張雙人
- <td>1CD (3.6/71.0)
+ <td>1CD (<data>3.6</data>/<data>71.0</data>)
  <td><font color=red>18禁</font>
  <td>SGCD063
 
@@ -877,7 +877,7 @@
  <td>2001
  <td>Active (TGL)
  <td>13張雙人
- <td>2CD (218)
+ <td>2CD (<data>218</data>)
  <td>Windows，<font color=red>18禁</font>
  <td>SGCD067
 
@@ -907,7 +907,7 @@
  <td>1995
  <td>天堂鳥
  <td>13張雙人
- <td>1CD (4.4/20.3)
+ <td>1CD (<data>4.4</data>/<data>20.3</data>)
  <td><font color=red>18禁</font>
  <td>SGCD111
 
@@ -937,7 +937,7 @@
  <td>2000
  <td>詮積
  <td>13張雙人
- <td>1CD (49.7)
+ <td>1CD (<data>49.7</data>)
  <td>Windows，<font color=red>18禁</font>
  <td>SGCD080
 
@@ -967,7 +967,7 @@
  <td>2001
  <td>伊思儷
  <td>13張雙人
- <td>1CD (381)
+ <td>1CD (<data>381</data>)
  <td>Windows，<font color=red>18禁</font>
  <td>SGCD130
 
@@ -987,7 +987,7 @@
  <td>2002
  <td>伊世紀
  <td>13張雙人
- <td>1CD (59.5)
+ <td>1CD (<data>59.5</data>)
  <td>Windows
  <td>SGCD108
 
@@ -997,7 +997,7 @@
  <td>2003
  <td>智冠
  <td>13張雙人/四人
- <td>1CD (120)
+ <td>1CD (<data>120</data>)
  <td>Windows
  <td>SGCD029
 
@@ -1067,7 +1067,7 @@
  <td>1997
  <td>SunSoft
  <td>四川省
- <td>1CD (8.6)
+ <td>1CD (<data>8.6</data>)
  <td>Win31/XP
  <td>SGCD109
 
@@ -1077,7 +1077,7 @@
  <td>1998
  <td>光譜
  <td>四川省
- <td>1CD (4.4)
+ <td>1CD (<data>4.4</data>)
  <td>Windows
  <td>SGCD064
 
@@ -1097,7 +1097,7 @@
  <td>1999
  <td>大點科技 (第三波)
  <td>四川省
- <td>1CD (35.5)
+ <td>1CD (<data>35.5</data>)
  <td>Windows，<font color=red>18禁</font>
  <td>SGCD107
 
@@ -1107,7 +1107,7 @@
  <td>2000
  <td>奈德
  <td>四川省
- <td>1CD (2.0)
+ <td>1CD (<data>2.0</data>)
  <td>Windows
  <td>SGCD060
 
@@ -1117,7 +1117,7 @@
  <td>2002
  <td>伊世紀
  <td>四川省
- <td>1CD (2.2)
+ <td>1CD (<data>2.2</data>)
  <td>Windows
  <td>SGCD114
 

--- a/game/game/cgame42.htm
+++ b/game/game/cgame42.htm
@@ -8,12 +8,9 @@
 
 <body>
 
-<div style="text-align: center; color: #800000; font-family: 標楷體;">
-<b><big><big>中文麻將類</big></big></b>
-</div>
-
 <small>
 <table border="1" width="100%" cellspacing="0" cellpadding="2">
+<caption style="text-align:center; color:#800000; font:bold 1.8em 標楷體;">中文麻將類</caption>
 
 <tr bgcolor=blue style="color:white; position:sticky; top:0;">
  <td>遊戲名稱

--- a/game/game/cgame42.htm
+++ b/game/game/cgame42.htm
@@ -647,7 +647,7 @@
  <td>2008
  <td>杉立
  <td>16張四人
- <td>1CD
+ <td>1CD<data>
  <td>WinXP
  <td>SGCD122
 
@@ -757,7 +757,7 @@
  <td>1997
  <td>Catgod
  <td>13張四人
- <td>1CD
+ <td>1CD<data>
  <td>Win9x
  <td>SGCD123
 
@@ -1137,7 +1137,7 @@
  <td>2002
  <td>新造科技
  <td>象棋麻將
- <td>2CD
+ <td>2CD<data>
  <td>Windows
  <td>SGCD082
 

--- a/game/game/cgame43.htm
+++ b/game/game/cgame43.htm
@@ -8,12 +8,9 @@
 
 <body>
 
-<div style="text-align: center; color: #800000; font-family: 標楷體;">
-<b><big><big>中文大富翁類</big></big></b>
-</div>
-
 <small>
 <table border="1" width="100%" cellspacing="0" cellpadding="2">
+<caption style="text-align:center; color:#800000; font:bold 1.8em 標楷體;">中文大富翁類</caption>
 
 <tr bgcolor=blue style="color:white; position:sticky; top:0;">
  <td>遊戲名稱

--- a/game/game/cgame43.htm
+++ b/game/game/cgame43.htm
@@ -26,7 +26,7 @@
  <td>****
  <td>1989
  <td>大宇
- <td>1CD (0.2)
+ <td>1CD (<data>0.2</data>)
  <td>無
  <td>DISK010,SGCD057
 
@@ -35,7 +35,7 @@
  <td>*****
  <td>1993
  <td>大宇
- <td>1CD (1.4)
+ <td>1CD (<data>1.4</data>)
  <td>無
  <td>DISK034,SGCD057
 
@@ -44,7 +44,7 @@
  <td>*****
  <td>1996
  <td>大宇
- <td>1CD (9.6)
+ <td>1CD (<data>9.6</data>)
  <td>無
  <td>DISK051,SGCD054,057
 
@@ -53,7 +53,7 @@
  <td>*****
  <td>1998
  <td>大宇
- <td>3CD (477)
+ <td>3CD (<data>477</data>)
  <td>無
  <td>SGCD048
 
@@ -62,7 +62,7 @@
  <td>*****
  <td>1996
  <td>智冠
- <td>1CD (8.6)
+ <td>1CD (<data>8.6</data>)
  <td>無
  <td>SGCD070
 

--- a/game/game/cgame44.htm
+++ b/game/game/cgame44.htm
@@ -168,7 +168,7 @@
  <td>1998
  <td>普威爾
  <td>拼圖
- <td>1CD
+ <td>1CD<data>
  <td>Windows
  <td>SGCD120
 
@@ -178,7 +178,7 @@
  <td>2002
  <td>新造科技
  <td>拼圖
- <td>2CD
+ <td>2CD<data>
  <td>Windows
  <td>SGCD082
 

--- a/game/game/cgame44.htm
+++ b/game/game/cgame44.htm
@@ -8,12 +8,9 @@
 
 <body>
 
-<div style="text-align: center; color: #800000; font-family: 標楷體;">
-<b><big><big>中文益智類</big></big></b>
-</div>
-
 <small>
 <table border="1" width="100%" cellspacing="0" cellpadding="2">
+<caption style="text-align:center; color:#800000; font:bold 1.8em 標楷體;">中文益智類</caption>
 
 <tr bgcolor=blue style="color:white; position:sticky; top:0;">
  <td>遊戲名稱

--- a/game/game/cgame44.htm
+++ b/game/game/cgame44.htm
@@ -88,7 +88,7 @@
  <td>1996
  <td>頂尖拍檔 (松崗)
  <td>俄羅斯方塊
- <td>1CD (14.8)
+ <td>1CD (<data>14.8</data>)
  <td>Windows
  <td>SGCD068
 
@@ -98,7 +98,7 @@
  <td>1997
  <td>龍愛 (智冠)
  <td>俄羅斯方塊
- <td>1CD (4.5)
+ <td>1CD (<data>4.5</data>)
  <td>Windows
  <td>SGCD091
 
@@ -108,7 +108,7 @@
  <td>2002
  <td>伊世紀
  <td>打磚塊
- <td>1CD (12.1)
+ <td>1CD (<data>12.1</data>)
  <td>Windows
  <td>SGCD114
 

--- a/game/game/cgame51.htm
+++ b/game/game/cgame51.htm
@@ -105,7 +105,9 @@
 </table>
 </small>
 
-<p><small>
+<p></p>
+
+<small>
 <table border="1" width="100%" cellspacing="0" cellpadding="2">
 <caption style="text-align:center; color:#800000; font:bold 1.8em 標楷體;">中文格鬥類</caption>
 

--- a/game/game/cgame51.htm
+++ b/game/game/cgame51.htm
@@ -78,7 +78,7 @@
  <td>1997
  <td>Seibu
  <td>捲軸
- <td>1CD (4.8)
+ <td>1CD (<data>4.8</data>)
  <td>Windows
  <td>SGCD062
 
@@ -152,7 +152,7 @@
  <td>****
  <td>1996
  <td>大宇
- <td>1CD (16.2/55.2)
+ <td>1CD (<data>16.2</data>/<data>55.2</data>)
  <td>無
  <td>DISK052,SGCD020
 

--- a/game/game/cgame51.htm
+++ b/game/game/cgame51.htm
@@ -8,12 +8,9 @@
 
 <body>
 
-<div style="text-align: center; color: #800000; font-family: 標楷體;">
-<b><big><big>中文射擊類</big></big></b>
-</div>
-
 <small>
 <table border="1" width="100%" cellspacing="0" cellpadding="2">
+<caption style="text-align:center; color:#800000; font:bold 1.8em 標楷體;">中文射擊類</caption>
 
 <tr bgcolor=blue style="color:white; position:sticky; top:0;">
  <td>遊戲名稱
@@ -108,12 +105,9 @@
 </table>
 </small>
 
-<p><div style="text-align: center; color: #800000; font-family: 標楷體;">
-<b><big><big>中文格鬥類</big></big></b>
-</div>
-
-<small>
+<p><small>
 <table border="1" width="100%" cellspacing="0" cellpadding="2">
+<caption style="text-align:center; color:#800000; font:bold 1.8em 標楷體;">中文格鬥類</caption>
 
 <tr bgcolor=blue style="color:white; position:sticky; top:0;">
  <td>遊戲名稱

--- a/game/game/cgame52.htm
+++ b/game/game/cgame52.htm
@@ -60,7 +60,8 @@
 </table>
 </small>
 
-<p>
+<p></p>
+
 <small>
 <table border="1" width="100%" cellspacing="0" cellpadding="2">
 <caption style="text-align:center; color:#800000; font:bold 1.8em 標楷體;">中文動作類</caption>

--- a/game/game/cgame52.htm
+++ b/game/game/cgame52.htm
@@ -143,7 +143,7 @@
  <td>*****
  <td>1997
  <td>龍愛
- <td>1CD (10.6)
+ <td>1CD (<data>10.6</data>)
  <td>無
  <td>SGCD089
 

--- a/game/game/cgame52.htm
+++ b/game/game/cgame52.htm
@@ -8,12 +8,9 @@
 
 <body>
 
-<div style="text-align: center; color: #800000; font-family: 標楷體;">
-<b><big><big>中文運動類</big></big></b>
-</div>
-
 <small>
 <table border="1" width="100%" cellspacing="0" cellpadding="2">
+<caption style="text-align:center; color:#800000; font:bold 1.8em 標楷體;">中文運動類</caption>
 
 <tr bgcolor=blue style="color:white; position:sticky; top:0;">
  <td>遊戲名稱
@@ -64,12 +61,9 @@
 </small>
 
 <p>
-<div style="text-align: center; color: #800000; font-family: 標楷體;">
-<b><big><big>中文動作類</big></big></b>
-</div>
-
 <small>
 <table border="1" width="100%" cellspacing="0" cellpadding="2">
+<caption style="text-align:center; color:#800000; font:bold 1.8em 標楷體;">中文動作類</caption>
 
 <tr bgcolor=blue style="color:white; position:sticky; top:0;">
  <td>遊戲名稱

--- a/game/game/egame11.htm
+++ b/game/game/egame11.htm
@@ -8,12 +8,9 @@
 
 <body>
 
-<div style="text-align: center; color: #800000; font-family: 標楷體;">
-<b><big><big>英文回合角色扮演類</big></big></b>
-</div>
-
 <small>
 <table border="1" width="100%" cellspacing="0" cellpadding="2">
+<caption style="text-align:center; color:#800000; font:bold 1.8em 標楷體;">英文回合角色扮演類</caption>
 
 <tr bgcolor=blue style="color:white; position:sticky; top:0;">
  <td>遊戲名稱

--- a/game/game/egame12.htm
+++ b/game/game/egame12.htm
@@ -98,7 +98,7 @@
  <td>*****
  <td>1998
  <td>New World Computing
- <td>2CD
+ <td>2CD<data>
  <td>Windows
  <td>OGCD018
 
@@ -107,7 +107,7 @@
  <td>*****
  <td>1999
  <td>New World Computing
- <td>2CD
+ <td>2CD<data>
  <td>Windows
  <td>SGCD003
 
@@ -116,7 +116,7 @@
  <td>*****
  <td>2000
  <td>New World Computing
- <td>2CD
+ <td>2CD<data>
  <td>Windows
  <td>OGCD035<br>(已換成可執行版)
 

--- a/game/game/egame12.htm
+++ b/game/game/egame12.htm
@@ -8,12 +8,9 @@
 
 <body>
 
-<div style="text-align: center; color: #800000; font-family: 標楷體;">
-<b><big><big>英文即時角色扮演類</big></big></b>
-</div>
-
 <small>
 <table border="1" width="100%" cellspacing="0" cellpadding="2">
+<caption style="text-align:center; color:#800000; font:bold 1.8em 標楷體;">英文即時角色扮演類</caption>
 
 <tr bgcolor=blue style="color:white; position:sticky; top:0;">
  <td>遊戲名稱

--- a/game/game/egame12.htm
+++ b/game/game/egame12.htm
@@ -89,7 +89,7 @@
  <td>*****
  <td>1995
  <td>Interplay
- <td>1CD (296)
+ <td>1CD (<data>296</data>)
  <td>無
  <td>OGCD019
 

--- a/game/game/egame21.htm
+++ b/game/game/egame21.htm
@@ -8,12 +8,9 @@
 
 <body>
 
-<div style="text-align: center; color: #800000; font-family: 標楷體;">
-<b><big><big>英文冒險解謎類</big></big></b>
-</div>
-
 <small>
 <table border="1" width="100%" cellspacing="0" cellpadding="2">
+<caption style="text-align:center; color:#800000; font:bold 1.8em 標楷體;">英文冒險解謎類</caption>
 
 <tr bgcolor=blue style="color:white; position:sticky; top:0;">
  <td>遊戲名稱

--- a/game/game/egame22.htm
+++ b/game/game/egame22.htm
@@ -8,12 +8,9 @@
 
 <body>
 
-<div style="text-align: center; color: #800000; font-family: 標楷體;">
-<b><big><big>英文故事劇情類</big></big></b>
-</div>
-
 <small>
 <table border="1" width="100%" cellspacing="0" cellpadding="2">
+<caption style="text-align:center; color:#800000; font:bold 1.8em 標楷體;">英文故事劇情類</caption>
 
 <tr bgcolor=blue style="color:white; position:sticky; top:0;">
  <td>遊戲名稱

--- a/game/game/egame31.htm
+++ b/game/game/egame31.htm
@@ -8,12 +8,9 @@
 
 <body>
 
-<div style="text-align: center; color: #800000; font-family: 標楷體;">
-<b><big><big>英文策略角色扮演類</big></big></b>
-</div>
-
 <small>
 <table border="1" width="100%" cellspacing="0" cellpadding="2">
+<caption style="text-align:center; color:#800000; font:bold 1.8em 標楷體;">英文策略角色扮演類</caption>
 
 <tr bgcolor=blue style="color:white; position:sticky; top:0;">
  <td>遊戲名稱

--- a/game/game/egame32.htm
+++ b/game/game/egame32.htm
@@ -8,12 +8,9 @@
 
 <body>
 
-<div style="text-align: center; color: #800000; font-family: 標楷體;">
-<b><big><big>英文計策戰略類</big></big></b>
-</div>
-
 <small>
 <table border="1" width="100%" cellspacing="0" cellpadding="2">
+<caption style="text-align:center; color:#800000; font:bold 1.8em 標楷體;">英文計策戰略類</caption>
 
 <tr bgcolor=blue style="color:white; position:sticky; top:0;">
  <td>遊戲名稱

--- a/game/game/egame33.htm
+++ b/game/game/egame33.htm
@@ -8,12 +8,9 @@
 
 <body>
 
-<div style="text-align: center; color: #800000; font-family: 標楷體;">
-<b><big><big>英文模擬養成類</big></big></b>
-</div>
-
 <small>
 <table border="1" width="100%" cellspacing="0" cellpadding="2">
+<caption style="text-align:center; color:#800000; font:bold 1.8em 標楷體;">英文模擬養成類</caption>
 
 <tr bgcolor=blue style="color:white; position:sticky; top:0;">
  <td>遊戲名稱

--- a/game/game/egame41.htm
+++ b/game/game/egame41.htm
@@ -365,7 +365,8 @@
 </table>
 </small>
 
-<p>
+<p></p>
+
 <small>
 <table border="1" width="100%" cellspacing="0" cellpadding="2">
 <caption style="text-align:center; color:#800000; font:bold 1.8em 標楷體;">英文牌類</caption>

--- a/game/game/egame41.htm
+++ b/game/game/egame41.htm
@@ -8,12 +8,9 @@
 
 <body>
 
-<div style="text-align: center; color: #800000; font-family: 標楷體;">
-<b><big><big>英文棋類</big></big></b>
-</div>
-
 <small>
 <table border="1" width="100%" cellspacing="0" cellpadding="2">
+<caption style="text-align:center; color:#800000; font:bold 1.8em 標楷體;">英文棋類</caption>
 
 <tr bgcolor=blue style="color:white; position:sticky; top:0;">
  <td>遊戲名稱
@@ -369,12 +366,9 @@
 </small>
 
 <p>
-<div style="text-align: center; color: #800000; font-family: 標楷體;">
-<b><big><big>英文牌類</big></big></b>
-</div>
-
 <small>
 <table border="1" width="100%" cellspacing="0" cellpadding="2">
+<caption style="text-align:center; color:#800000; font:bold 1.8em 標楷體;">英文牌類</caption>
 
 <tr bgcolor=blue style="color:white; position:sticky; top:0;">
  <td>遊戲名稱

--- a/game/game/egame41.htm
+++ b/game/game/egame41.htm
@@ -138,7 +138,7 @@
  <td>1988
  <td>Interplay
  <td>西洋棋
- <td>1CD (0.5)
+ <td>1CD (<data>0.5</data>)
  <td>無
  <td>SGCD061
 
@@ -248,7 +248,7 @@
  <td>2003
  <td>Fluent
  <td>西洋棋
- <td>1CD (164)
+ <td>1CD (<data>164</data>)
  <td>Windows
  <td>SGCD096
 

--- a/game/game/egame42.htm
+++ b/game/game/egame42.htm
@@ -8,12 +8,9 @@
 
 <body>
 
-<div style="text-align: center; color: #800000; font-family: 標楷體;">
-<b><big><big>英文麻將類</big></big></b>
-</div>
-
 <small>
 <table border="1" width="100%" cellspacing="0" cellpadding="2">
+<caption style="text-align:center; color:#800000; font:bold 1.8em 標楷體;">英文麻將類</caption>
 
 <tr bgcolor=blue style="color:white; position:sticky; top:0;">
  <td>遊戲名稱

--- a/game/game/egame43.htm
+++ b/game/game/egame43.htm
@@ -8,12 +8,9 @@
 
 <body>
 
-<div style="text-align: center; color: #800000; font-family: 標楷體;">
-<b><big><big>英文大富翁類</big></big></b>
-</div>
-
 <small>
 <table border="1" width="100%" cellspacing="0" cellpadding="2">
+<caption style="text-align:center; color:#800000; font:bold 1.8em 標楷體;">英文大富翁類</caption>
 
 <tr bgcolor=blue style="color:white; position:sticky; top:0;">
  <td>遊戲名稱

--- a/game/game/egame44.htm
+++ b/game/game/egame44.htm
@@ -8,12 +8,9 @@
 
 <body>
 
-<div style="text-align: center; color: #800000; font-family: 標楷體;">
-<b><big><big>英文益智類</big></big></b>
-</div>
-
 <small>
 <table border="1" width="100%" cellspacing="0" cellpadding="2">
+<caption style="text-align:center; color:#800000; font:bold 1.8em 標楷體;">英文益智類</caption>
 
 <tr bgcolor=blue style="color:white; position:sticky; top:0;">
  <td>遊戲名稱

--- a/game/game/egame51.htm
+++ b/game/game/egame51.htm
@@ -8,12 +8,9 @@
 
 <body>
 
-<div style="text-align: center; color: #800000; font-family: 標楷體;">
-<b><big><big>英文射擊類</big></big></b>
-</div>
-
 <small>
 <table border="1" width="100%" cellspacing="0" cellpadding="2">
+<caption style="text-align:center; color:#800000; font:bold 1.8em 標楷體;">英文射擊類</caption>
 
 <tr bgcolor=blue style="color:white; position:sticky; top:0;">
  <td>遊戲名稱
@@ -269,12 +266,9 @@
 </small>
 
 <p>
-<div style="text-align: center; color: #800000; font-family: 標楷體;">
-<b><big><big>英文格鬥類</big></big></b>
-</div>
-
 <small>
 <table border="1" width="100%" cellspacing="0" cellpadding="2">
+<caption style="text-align:center; color:#800000; font:bold 1.8em 標楷體;">英文格鬥類</caption>
 
 <tr bgcolor=blue style="color:white; position:sticky; top:0;">
  <td>遊戲名稱

--- a/game/game/egame51.htm
+++ b/game/game/egame51.htm
@@ -148,7 +148,7 @@
  <td>1995
  <td>id Software
  <td>第一人稱
- <td>1CD (8.1/57.3)
+ <td>1CD (<data>8.1</data>/<data>57.3</data>)
  <td>無
  <td>OGCD054
 
@@ -238,7 +238,7 @@
  <td>2005
  <td>Seibu
  <td>捲軸
- <td>1CD (152)
+ <td>1CD (<data>152</data>)
  <td>Windows
  <td>SGCD072
 

--- a/game/game/egame51.htm
+++ b/game/game/egame51.htm
@@ -265,7 +265,8 @@
 </table>
 </small>
 
-<p>
+<p></p>
+
 <small>
 <table border="1" width="100%" cellspacing="0" cellpadding="2">
 <caption style="text-align:center; color:#800000; font:bold 1.8em 標楷體;">英文格鬥類</caption>

--- a/game/game/egame52.htm
+++ b/game/game/egame52.htm
@@ -24,7 +24,8 @@
 </table>
 </small>
 
-<p>
+<p></p>
+
 <small>
 <table border="1" width="100%" cellspacing="0" cellpadding="2">
 <caption style="text-align:center; color:#800000; font:bold 1.8em 標楷體;">英文動作類</caption>

--- a/game/game/egame52.htm
+++ b/game/game/egame52.htm
@@ -62,7 +62,7 @@
  <td>*****
  <td>1995
  <td>Virgin
- <td>1CD (22.0)
+ <td>1CD (<data>22.0</data>)
  <td>無
  <td>SGCD002
 
@@ -71,7 +71,7 @@
  <td>****
  <td>1996
  <td>Virgin
- <td>1CD (163)
+ <td>1CD (<data>163</data>)
  <td>無
  <td>SGCD009
 
@@ -80,7 +80,7 @@
  <td>****
  <td>1997
  <td>Virgin
- <td>1CD (143)
+ <td>1CD (<data>143</data>)
  <td>無
  <td>SGCD010
 

--- a/game/game/egame52.htm
+++ b/game/game/egame52.htm
@@ -8,12 +8,9 @@
 
 <body>
 
-<div style="text-align: center; color: #800000; font-family: 標楷體;">
-<b><big><big>英文運動類</big></big></b>
-</div>
-
 <small>
 <table border="1" width="100%" cellspacing="0" cellpadding="2">
+<caption style="text-align:center; color:#800000; font:bold 1.8em 標楷體;">英文運動類</caption>
 
 <tr bgcolor=blue style="color:white; position:sticky; top:0;">
  <td>遊戲名稱
@@ -28,12 +25,9 @@
 </small>
 
 <p>
-<div style="text-align: center; color: #800000; font-family: 標楷體;">
-<b><big><big>英文動作類</big></big></b>
-</div>
-
 <small>
 <table border="1" width="100%" cellspacing="0" cellpadding="2">
+<caption style="text-align:center; color:#800000; font:bold 1.8em 標楷體;">英文動作類</caption>
 
 <tr bgcolor=blue style="color:white; position:sticky; top:0;">
  <td>遊戲名稱

--- a/game/game/list.htm
+++ b/game/game/list.htm
@@ -1,0 +1,306 @@
+﻿<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>遊戲總表</title>
+<style>
+table.sortable > thead > tr > td { cursor: pointer; }
+table.sortable > thead > tr > td::after { content: "↕"; }
+table.sortable > thead > tr > td[data-order="1"]::after { content: "↓"; }
+table.sortable > thead > tr > td[data-order="-1"]::after { content: "↑"; }
+</style>
+<script>
+(function (globalThis) {
+
+const tableLoader = {
+  conf: {
+    filelist: 'menu.htm',
+    tableSelector: 'table',
+    tableRowTemplateSelector: 'template',
+    loggerSelector: '#message',
+  },
+  async init() {
+    const tableElem = document.querySelector(this.conf.tableSelector);
+    const tbodyElem = tableElem.tBodies[0];
+    const tableRowTemplateElem = document.querySelector(this.conf.tableRowTemplateSelector);
+    const loggerElem = this.loggerElem = document.querySelector(this.conf.loggerSelector);
+
+    loggerElem.textContent = '載入中...';
+    tableElem.hidden = true;
+
+    try {
+      // initialize header key map
+      const mapKeyToIdx = Array.prototype.reduce.call(
+        tableElem.querySelectorAll(':scope > thead:first-of-type > tr:first-of-type > td'),
+        (map, elem, idx) => {
+          const key = this.parseKey(elem.textContent);
+          map[key] = idx;
+          return map;
+        }, {});
+
+      // load file list
+      const url = this.conf.filelist;
+      const xhr = await this.xhr({
+        url,
+        responseType: 'document',
+        overrideMimeType: 'text/html',
+      }).catch(ex => {
+        throw new Error(`無法載入 "${url}": ${ex.message}`);
+      });
+      const filelistDoc = xhr.response;
+
+      // load files
+      const p = Array.prototype.map.call(filelistDoc.querySelectorAll('a.toc'), (a) => {
+        const url = a.href;
+        return this.xhr({
+          url,
+          responseType: 'document',
+          overrideMimeType: 'text/html',
+        })
+        .then(r => r.response)
+        .catch((ex) => {
+          throw new Error(`無法載入 "${url}": ${ex.message}`);
+        });
+      });
+      const listDocs = await Promise.all(p);
+
+      // insert loaded data
+      for (const listDoc of listDocs) {
+        for (const table of listDoc.querySelectorAll('table')) {
+          const mapIdxToKey = Array.prototype.map.call(
+            table.querySelector(':scope > tbody > tr').querySelectorAll(':scope > td'),
+            (elem) => {
+              return this.parseKey(elem.textContent);
+            });
+
+          let first = true;
+          for (const row of table.querySelectorAll(':scope tbody > tr')) {
+            if (first) {
+              first = false;
+              continue;
+            }
+            const newRow = document.importNode(tableRowTemplateElem.content, true);
+            const newRowCells = newRow.querySelectorAll('td');
+            let i = 0, elem;
+            for (const cell of row.querySelectorAll(':scope > td')) {
+              const idx = mapKeyToIdx[mapIdxToKey[i++]];
+              if (!Number.isInteger(idx)) { continue; }
+              const newCell = newRowCells[idx];
+              if (!newCell) { continue; }
+              while (elem = cell.firstChild) { newCell.appendChild(elem); }
+            }
+            tbodyElem.appendChild(newRow);
+          }
+        }
+      }
+    } catch (ex) {
+      console.error(ex);
+      loggerElem.textContent = ex.message;
+      return;
+    }
+
+    loggerElem.textContent = '';
+    tableElem.hidden = false;
+  },
+  async xhr(params = {}) {
+    return new Promise((resolve, reject) => {
+      const xhr = new XMLHttpRequest();
+      xhr.onload = (event) => {
+        resolve(xhr);
+      };
+      xhr.onabort = (event) => {
+        resolve();
+      };
+      xhr.onerror = (event) => {
+        reject(new Error('Network request failed.'));
+      };
+      xhr.ontimeout = (event) => {
+        reject(new Error('Request timeout.'));
+      };
+      xhr.responseType = params.responseType;
+      if (params.overrideMimeType) { xhr.overrideMimeType(params.overrideMimeType); }
+      xhr.open(params.method || 'GET', params.url, true);
+      if (params.timeout) { xhr.timeout = params.timeout; }
+      xhr.send(params.formData);
+    });
+  },
+  parseKey(str) {
+    return str.trim();
+  },
+};
+
+globalThis.document.addEventListener('DOMContentLoaded', () => {
+  tableLoader.init();
+}, false);
+
+globalThis.tableLoader = tableLoader;
+
+})(this);
+</script>
+<script>
+(function (globalThis) {
+
+const tableSorter = {
+  conf: {
+    tableSelector: 'table.sortable',
+    defaultParser: 'utf8',
+    parsers: {
+      /**
+       * Retrieve data from elem.
+       * May be a single value or multiple <data> defined values.
+       */
+      getData(elem) {
+        const dataElems = elem.querySelectorAll('data');
+        if (dataElems.length) {
+          return Array.prototype.map.call(dataElems, (elem) => {
+            if (elem.hasAttribute('value')) {
+              return elem.value;
+            }
+            return this.getText(elem);
+          });
+        }
+        return [this.getText(elem)];
+      },
+      /**
+       * Retrieve text from elem.
+       * Replace <br> with \n and trim leading and trailing spaces.
+       */
+      getText(elem) {
+        const elemClone = elem.cloneNode(true);
+        for (const e of elemClone.querySelectorAll('br')) {
+          e.replaceWith('\n');
+        }
+        return elemClone.textContent.trim();
+      },
+      utf16(elem) {
+        return this.getData(elem);
+      },
+      utf8(elem) {
+        return this.getData(elem).map(text => {
+          return unescape(encodeURIComponent(text));
+        });
+      },
+      int(elem) {
+        return this.getData(elem).map(text => {
+          const val = parseInt(text, 10);
+          return !Number.isNaN(val) ? val : -Infinity;
+        });
+      },
+      float(elem) {
+        return this.getData(elem).map(text => {
+          const val = parseFloat(text);
+          return !Number.isNaN(val) ? val : -Infinity;
+        });
+      },
+    },
+  },
+  init() {
+    for (const table of document.querySelectorAll(this.conf.tableSelector)) {
+      for (const elem of table.querySelectorAll(':scope > thead:first-of-type > tr:first-of-type > td')) {
+        elem.addEventListener('click', this.onHeaderClickOrKeyPress.bind(this), false);
+        elem.addEventListener('keypress', this.onHeaderClickOrKeyPress.bind(this), false);
+      }
+    }
+  },
+  sortBy(table, idx, order) {
+    const headerCell = table.querySelectorAll(':scope > thead:first-of-type > tr:first-of-type > td')[idx];
+    if (order === undefined) {
+      order = (parseInt(headerCell.getAttribute('data-order'), 10) === 1) ? -1 : 1;
+    }
+    headerCell.setAttribute('data-order', order);
+
+    const defaultParser = this.conf.defaultParser;
+    const parsers = this.conf.parsers;
+    const method = headerCell.getAttribute('data-sort');
+    const parser = parsers[method] || parsers[defaultParser];
+    const tbody = table.tBodies[0];
+    const rows = Array.from(tbody.rows);
+    rows.sort((a, b) => {
+      const da = parser.call(parsers, a.cells[idx]);
+      const db = parser.call(parsers, b.cells[idx]);
+      for (let i = 0, I = Math.max(da.length, db.length); i < I; i++) {
+        const ka = da[i];
+        const kb = db[i];
+        if (ka === undefined) {
+          return -order;
+        }
+        if (kb === undefined) {
+          return order;
+        }
+        if (ka < kb) {
+          return -order;
+        }
+        if (ka > kb) {
+          return order;
+        }
+      }
+      return 0;
+    });
+    for (let row of rows) {
+      tbody.appendChild(row);
+    }
+  },
+  onHeaderClickOrKeyPress(event) {
+    const elem = event.currentTarget;
+
+    // pass if a link inside the cell is clicked
+    const a = event.target.closest('a[href], area[href]');
+    if (a && elem.contains(a)) { return; }
+
+    if (event.type === 'keypress' && event.key !== 'Enter') { return; }
+
+    event.preventDefault();
+    const tr = elem.closest('tr');
+    const idx = Array.prototype.indexOf.call(tr.querySelectorAll(':scope > td'), elem);
+    if (idx < 0) { return; }
+    this.sortBy(tr.closest('table'), idx);
+  },
+};
+
+globalThis.document.addEventListener('DOMContentLoaded', () => {
+  tableSorter.init();
+}, false);
+
+globalThis.tableSorter = tableSorter;
+
+})(this);
+</script>
+</head>
+<body>
+
+<div style="text-align: center; color: #800000; font-family: 標楷體;">
+<b><big><big>遊戲總表</big></big></b>
+</div>
+
+<div id="message">
+瀏覽器須支援 JavaScript (版本 ES2015) 才能正常執行本頁功能。
+</div>
+
+<small>
+<table class="sortable" border="1" width="100%" cellspacing="0" cellpadding="2" hidden>
+<thead>
+<tr bgcolor=blue style="color:white; position:sticky; top:0;">
+  <td tabindex=0>遊戲名稱
+  <td tabindex=0>評價
+  <td tabindex=0 data-sort="int">年代
+  <td tabindex=0>公司
+  <td tabindex=0 data-sort="float">大小
+  <td tabindex=0>限制
+  <td tabindex=0>位置
+<tbody>
+</table>
+</small>
+
+<template id="tablerow">
+<tr>
+ <td>
+ <td>
+ <td>
+ <td>
+ <td>
+ <td>
+ <td>
+</template>
+
+</body>
+</html>

--- a/game/game/list.htm
+++ b/game/game/list.htm
@@ -65,6 +65,7 @@ const tableLoader = {
       const listDocs = await Promise.all(p);
 
       // insert loaded data
+      let tableIdx = 0;
       for (const listDoc of listDocs) {
         for (const table of listDoc.querySelectorAll('table')) {
           const mapIdxToKey = Array.prototype.map.call(
@@ -72,6 +73,9 @@ const tableLoader = {
             (elem) => {
               return this.parseKey(elem.textContent);
             });
+
+          const captionElem = table.querySelector(':scope > caption');
+          const caption = captionElem ? this.parseKey(captionElem.textContent) : '';
 
           let first = true;
           for (const row of table.querySelectorAll(':scope tbody > tr')) {
@@ -89,8 +93,18 @@ const tableLoader = {
               if (!newCell) { continue; }
               while (elem = cell.firstChild) { newCell.appendChild(elem); }
             }
+
+            // add type
+            const cell = newRowCells[mapKeyToIdx['分類']];
+            if (cell) {
+              if (caption) { cell.title = caption; }
+              cell.textContent = tableIdx + 1;
+            }
+
             tbodyElem.appendChild(newRow);
           }
+
+          tableIdx++;
         }
       }
     } catch (ex) {
@@ -280,6 +294,7 @@ globalThis.tableSorter = tableSorter;
 <table class="sortable" border="1" width="100%" cellspacing="0" cellpadding="2" hidden>
 <thead>
 <tr bgcolor=blue style="color:white; position:sticky; top:0;">
+  <td tabindex=0 data-sort="int">分類
   <td tabindex=0>遊戲名稱
   <td tabindex=0>評價
   <td tabindex=0 data-sort="int">年代
@@ -293,6 +308,7 @@ globalThis.tableSorter = tableSorter;
 
 <template id="tablerow">
 <tr>
+ <td>
  <td>
  <td>
  <td>

--- a/game/game/menu.htm
+++ b/game/game/menu.htm
@@ -17,39 +17,39 @@
 
 <tr><td bgcolor="#00FF00"><font color="#800000">遊戲專區</font>
 
-<tr><td><a href="list-1.htm">遊戲總表</a>
+<tr><td><a href="list.htm">遊戲總表</a>
 
 <tr><td>中文遊戲 561
 
-<tr><td>　<a href="cgame11.htm">回合RPG</a> 83
-<tr><td>　<a href="cgame12.htm">即時RPG</a> 34
-<tr><td>　<a href="cgame31.htm">策略RPG</a> 34
-<tr><td>　<a href="cgame21.htm">冒險解謎</a> 21
-<tr><td>　<a href="cgame22.htm">故事劇情</a> 28
-<tr><td>　<a href="cgame32.htm">計策戰略</a> 21
-<tr><td>　<a href="cgame33.htm">模擬養成</a> 19
-<tr><td>　<a href="cgame41.htm">棋牌</a> 127
-<tr><td>　<a href="cgame42.htm">麻將</a> 113
-<tr><td>　<a href="cgame43.htm">大富翁</a> 20
-<tr><td>　<a href="cgame44.htm">益智</a> 32
-<tr><td>　<a href="cgame51.htm">射擊格鬥</a> 17
-<tr><td>　<a href="cgame52.htm">運動動作</a> 12
+<tr><td>　<a href="cgame11.htm" class="toc">回合RPG</a> 83
+<tr><td>　<a href="cgame12.htm" class="toc">即時RPG</a> 34
+<tr><td>　<a href="cgame31.htm" class="toc">策略RPG</a> 34
+<tr><td>　<a href="cgame21.htm" class="toc">冒險解謎</a> 21
+<tr><td>　<a href="cgame22.htm" class="toc">故事劇情</a> 28
+<tr><td>　<a href="cgame32.htm" class="toc">計策戰略</a> 21
+<tr><td>　<a href="cgame33.htm" class="toc">模擬養成</a> 19
+<tr><td>　<a href="cgame41.htm" class="toc">棋牌</a> 127
+<tr><td>　<a href="cgame42.htm" class="toc">麻將</a> 113
+<tr><td>　<a href="cgame43.htm" class="toc">大富翁</a> 20
+<tr><td>　<a href="cgame44.htm" class="toc">益智</a> 32
+<tr><td>　<a href="cgame51.htm" class="toc">射擊格鬥</a> 17
+<tr><td>　<a href="cgame52.htm" class="toc">運動動作</a> 12
 
 <tr><td>英文遊戲 109
 
-<tr><td>　<a href="egame11.htm">回合RPG</a> 2
-<tr><td>　<a href="egame12.htm">即時RPG</a> 12
-<tr><td>　<a href="egame31.htm">策略RPG</a> 0
-<tr><td>　<a href="egame21.htm">冒險解謎</a> 4
-<tr><td>　<a href="egame22.htm">故事劇情</a> 0
-<tr><td>　<a href="egame32.htm">計策戰略</a> 2
-<tr><td>　<a href="egame33.htm">模擬養成</a> 1
-<tr><td>　<a href="egame41.htm">棋牌</a> 39
-<tr><td>　<a href="egame42.htm">麻將</a> 7
-<tr><td>　<a href="egame43.htm">大富翁</a> 0
-<tr><td>　<a href="egame44.htm">益智</a> 13
-<tr><td>　<a href="egame51.htm">射擊格鬥</a> 24
-<tr><td>　<a href="egame52.htm">運動動作</a> 5
+<tr><td>　<a href="egame11.htm" class="toc">回合RPG</a> 2
+<tr><td>　<a href="egame12.htm" class="toc">即時RPG</a> 12
+<tr><td>　<a href="egame31.htm" class="toc">策略RPG</a> 0
+<tr><td>　<a href="egame21.htm" class="toc">冒險解謎</a> 4
+<tr><td>　<a href="egame22.htm" class="toc">故事劇情</a> 0
+<tr><td>　<a href="egame32.htm" class="toc">計策戰略</a> 2
+<tr><td>　<a href="egame33.htm" class="toc">模擬養成</a> 1
+<tr><td>　<a href="egame41.htm" class="toc">棋牌</a> 39
+<tr><td>　<a href="egame42.htm" class="toc">麻將</a> 7
+<tr><td>　<a href="egame43.htm" class="toc">大富翁</a> 0
+<tr><td>　<a href="egame44.htm" class="toc">益智</a> 13
+<tr><td>　<a href="egame51.htm" class="toc">射擊格鬥</a> 24
+<tr><td>　<a href="egame52.htm" class="toc">運動動作</a> 5
 
 <tr><td><a href="tools.htm">自製工具軟體</a> 5
 <tr><td><a href="cin/cin.htm">青衫個人作品</a>


### PR DESCRIPTION
試做了一個自動產生遊戲總表的功能，來提案看看：

1. 進入[測試頁](https://danny0838.github.io/chiuinan.github.io/game/game/list.htm) 或進入[主頁](https://danny0838.github.io/chiuinan.github.io/game/)後點擊「遊戲總表」連結進入。
2. 進入頁面後，會自動用 AJAX 載入目錄中的遊戲列表頁面，產生遊戲總表。
3. 點擊總表表頭的各欄位可以排序。截圖如下：
   ![圖片](https://github.com/chiuinan/chiuinan.github.io/assets/531417/cf5c9a34-70c8-4e34-8af4-07dbee9dc7b6)
   分類是根據載入的頁面和表格順序自動產生，由於文字比較長，因此用序號表示，滑鼠移過會顯示完整名稱。

補充說明：
1. 使用這個自動產生的總表，以後加入新遊戲或修改舊遊戲資訊只需更新各分表，不必另外手工更新遊戲總表、簡表。
2. 內建排序功能 (按 UTF-16)，以後表格的排序可直接交給電腦，省下排序的工夫，照自己可以接受的內在邏輯大概排一下即可。畢竟人工排序容易出錯，況且中文沒有統一的順序，無論是用 Big5、UTF-8、甚至注音、筆劃、倉頡碼等方式排序，都無法保證滿足所有人的需求。而且大多數使用者應該會直接搜尋，排得再好意義也不大。此外手工排序只能有一種順序，但自動排序可以有多種排序方式，對於有依評價、年代、公司等方式排序需求的使用者較方便。
3. 雖然需要用到樣式表和腳本，但全部都是內嵌在 `list.htm` 頁面，不影響其他頁面。未來若不想用直接刪除即可，非常綠色。刪除時找個瀏覽器把產生排序好的總表的HTML碼複製出來再稍作整理，即可得到排序好的手工總表。
4. 部分頁面內容格式要稍作微調，以配合自動化總表：
    1. menu.htm 需要讓總表載入的表格連結要加上 `class="toc"`。
    2. 各分表表格前的標題改為表格中的 caption，以便讓總表可自動載入表格分類。（不改也行，但分類就只會有序號而無名稱）
    3. 各分表中比較複雜的欄位需要人工標記資料，排序時才能取到正確數值。目前設計可用 `<data>值</data>` 或 `<data value="值">顯示文字</data>` 標記用於機器排序的值。（不改也行，但有些項目就會排序錯誤）
5. 實測掛在 GitHub Pages 載入、排序速度都相當快，無論是電腦或手機，數秒內即可完成，而即使第一次載入較慢，之後載入由於各分表頁面已有快取，載入就會比較快。
6. 有個小缺點是此技術使用 AJAX 載入內容，檔案放在本機時會受到同源政策影響而無法載入，如要在本機測試，須自架本機伺服器，或調整瀏覽器設定以關閉同源政策對 file URL 的嚴格限制：
    * **Chromium 系**（包括 Google Chrome、79 版以後的 Edge 等）: 建立瀏覽器應用程式的捷徑，在執行檔路徑後加上參數 `--allow-file-access-from-files`。
    * **Firefox 系**（包括 Tor Browser 等）: 於網址列輸入 `about:config`，搜尋 `security.fileuri.strict_origin_policy` 將值改為 `false`。
   > 這些設定會增加上網風險，建議使用獨立的瀏覽器帳號／設定檔、或瀏覽器程式，和平常上網的瀏覽器分開。

目前只是初版，如有細節需要改善或調整，都還可以再研究。